### PR TITLE
Expanded documentation on NED searches

### DIFF
--- a/html/firefly/catalogs.html
+++ b/html/firefly/catalogs.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <!--NewPage-->
 <HTML>
@@ -221,26 +220,39 @@ Extragalactic Database <img src="img/jumpout.jpg" height="10"></A>.)<P>
 
 By clicking on the blue "Catalogs" tab, you are by default dropped
 into the interface for searching for catalogs at IRSA. However, you
-can pick another tab, "NED", to search for and load a catalog from
-NED.<P>
+can pick another tab, "NED", to search for and load catalog data from
+NED.
+Using this interface you can superpose NED search results on search
+results you've already obtained from other sources.
+You also still have one-click access to the fully detailed information
+from NED on any object returned from such a search.<P>
 
 <img src="img/nedcat.png" width="75%"><P>
 
+This tab allows performing a cone search in the main NED object
+catalog around specified coordinates.
+As for other catalog searches, you can use an object name in place
+of coordinates (note that although NED is used for name resolution,
+the actual search then performed on NED is by coordinates, as
+opposed to a direct access of the NED object catalog by name).<P>
 
 As for the other catalog searches, the tool pre-fills the target
-position with its best guess o the coordinates of the target with
-which you have been working. In this case, you are limited to a cone
-search, so the next option is the cone search radius. Pick your units
+position with its best guess for the coordinates of a target with
+which you have already been working.
+The next option is the cone search radius.  Pick your units
 from the pulldown first, and then enter a number; if you enter a
 number and then select from the pulldown, it will convert your number
 from the old units to the new units. There are both upper and lower
 limits to your search radius; it will tell you if you request
-something too big or too small. <P>
-
+something too big or too small.<P>
 
 The search results are then shown (and interacted with) in the same
 way as the other catalogs described here.<P>
 
+The search results will generally include a column "Details".
+(You may have to scroll to the right to see it.)
+Clicking on a link in this column takes you directly to the full
+NED information display for the selected object, in a new window.
 
 <h3><a name="owncatalogs">Loading your own catalogs</A></h3><P>
 

--- a/html/firefly/catalogs.html
+++ b/html/firefly/catalogs.html
@@ -252,7 +252,7 @@ way as the other catalogs described here.<P>
 The search results will generally include a column "Details".
 (You may have to scroll to the right to see it.)
 Clicking on a link in this column takes you directly to the full
-NED information display for the selected object, in a new window.
+NED information display for the selected object, in a new window.<P>
 
 <h3><a name="owncatalogs">Loading your own catalogs</A></h3><P>
 

--- a/html/firefly/catalogs.html
+++ b/html/firefly/catalogs.html
@@ -224,7 +224,7 @@ can pick another tab, "NED", to search for and load catalog data from
 NED.
 Using this interface you can superpose NED search results on search
 results you've already obtained from other sources.
-You also still have one-click access to the fully detailed information
+You then have one-click access to the fully detailed information
 from NED on any object returned from such a search.<P>
 
 <img src="img/nedcat.png" width="75%"><P>


### PR DESCRIPTION
While fiddling with NED searches I thought I'd expand/clarify the documentation a bit.  See what you think.

I think it would also be nice to ask the Firefly team to put a subheading at the top of the search tab itself, something like "Search the NASA Extragalactic Database (NED) at IPAC by coordinates", maybe?  And a little NED icon?  @xiuqin if you like that idea, we can make a FIREFLY- ticket for that.